### PR TITLE
RediSearch v2: Added YCSB redisearch binding

### DIFF
--- a/bin/run-redis.sh
+++ b/bin/run-redis.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+./bin/ycsb load redis -s -P workloads/workloada -p "redis.host=127.0.0.1" -p "redis.port=6379" -p "threadcount=8" > outputLoad.txt
+
+./bin/ycsb run redis -s -P workloads/workloada -p "redis.host=127.0.0.1" -p "redis.port=6379" -p "threadcount=8" > outputRunA.txt
+./bin/ycsb run redis -s -P workloads/workloadb -p "redis.host=127.0.0.1" -p "redis.port=6379" -p "threadcount=8" > outputRunB.txt
+./bin/ycsb run redis -s -P workloads/workloadc -p "redis.host=127.0.0.1" -p "redis.port=6379" -p "threadcount=8" > outputRunC.txt
+./bin/ycsb run redis -s -P workloads/workloadf -p "redis.host=127.0.0.1" -p "redis.port=6379" -p "threadcount=8" > outputRunF.txt
+./bin/ycsb run redis -s -P workloads/workloadd -p "redis.host=127.0.0.1" -p "redis.port=6379" -p "threadcount=8" > outputRunD.txt
+
+redis-cli flushall
+
+./bin/ycsb load redis -s -P workloads/workloade -p "redis.host=127.0.0.1" -p "redis.port=6379" -p "threadcount=8" > outputLoad.txt
+./bin/ycsb run redis -s -P workloads/workloade -p "redis.host=127.0.0.1" -p "redis.port=6379" -p "threadcount=8" > outputRunE.txt

--- a/bin/ycsb
+++ b/bin/ycsb
@@ -93,6 +93,7 @@ DATABASES = {
     "postgrenosql" : "site.ycsb.postgrenosql.PostgreNoSQLDBClient",
     "rados"        : "site.ycsb.db.RadosClient",
     "redis"        : "site.ycsb.db.RedisClient",
+    "redisearch"   : "site.ycsb.db.RediSearchClient",
     "rest"         : "site.ycsb.webservice.rest.RestClient",
     "riak"         : "site.ycsb.db.riak.RiakKVClient",
     "rocksdb"      : "site.ycsb.db.rocksdb.RocksDBClient",
@@ -220,7 +221,7 @@ def get_classpath_from_maven(module):
         # the last module will be the datastore binding
         line = [x for x in mvn_output.splitlines() if x.startswith("classpath=")][-1:]
         return line[0][len("classpath="):]
-    except subprocess.CalledProcessError, err:
+    except subprocess.CalledProcessError as err:
         error("Attempting to generate a classpath from Maven failed "
               "with return code '" + str(err.returncode) + "'. The output from "
               "Maven follows, try running "

--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,7 @@ LICENSE file.
     <module>postgrenosql</module>
     <module>rados</module>
     <module>redis</module>
+    <module>redisearch</module>
     <module>rest</module>
     <module>riak</module>
     <module>rocksdb</module>

--- a/redisearch/README.md
+++ b/redisearch/README.md
@@ -1,0 +1,254 @@
+<!--
+Copyright (c) 2021 YCSB contributors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you
+may not use this file except in compliance with the License. You
+may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License. See accompanying
+LICENSE file.
+-->
+
+## Quick Start
+
+This section describes how to run YCSB on Redis with RediSearch[https://github.com/RediSearch/RediSearch] module enabled. 
+
+### 1. Start Redis with RediSearch 
+
+```
+(...)
+```
+
+### 2. Install Java and Maven
+
+### 3. Set Up YCSB
+
+Git clone YCSB and compile:
+
+    git clone http://github.com/RediSearch/YCSB.git --branch redisearch2.support
+    cd YCSB
+    mvn -pl site.ycsb:redisearch-binding -am clean package
+
+### 4. Provide Redis Connection Parameters
+    
+Set host, port, password, and cluster mode in the workload you plan to run. 
+
+- `redisearch.host`
+- `redisearch.port`
+- `redisearch.password`
+  * Don't set the password if redis auth is disabled.
+- `redisearch.cluster`
+  * Set the cluster parameter to `true` if redis cluster mode is enabled.
+  * Default is `false`.
+
+Or, you can set configs with the shell command, EG:
+
+    ./bin/ycsb load redisearch -s -P workloads/workloada -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=8" > outputLoad.txt
+
+
+### 5. Load data and run the tests
+
+All six workloads have a data set that is similar. Workloads D and E insert records during the test run. Thus, to keep the database size consistent, we recommend the following sequence:
+
+Load the database, using workload A’s parameter file (workloads/workloada) and the “-load” switch to the client.
+
+- Run workload A (using workloads/workloada and “-t”) for a variety of throughputs.
+
+- Run workload B (using workloads/workloadb and “-t”) for a variety of throughputs.
+
+- Run workload C (using workloads/workloadc and “-t”) for a variety of throughputs.
+
+- Run workload F (using workloads/workloadf and “-t”) for a variety of throughputs.
+
+- Run workload D (using workloads/workloadd and “-t”) for a variety of throughputs. This workload inserts records, increasing the size of the database.
+
+- Delete the data in the database.
+
+- Reload the database, using workload E’s parameter file (workloads/workloade) and the "-load switch to the client.
+
+- Run workload E (using workloads/workloade and “-t”) for a variety of throughputs. This workload inserts records, increasing the size of the database.
+
+
+```bash
+# load, run A, B, C, F, D, (flushdb), load, E
+./bin/ycsb load redisearch -s -P workloads/workloada -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=8" > outputLoad.txt
+
+./bin/ycsb run redisearch -s -P workloads/workloada -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=8" > outputRunA.txt
+./bin/ycsb run redisearch -s -P workloads/workloadb -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=8" > outputRunB.txt
+./bin/ycsb run redisearch -s -P workloads/workloadc -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=8" > outputRunC.txt
+./bin/ycsb run redisearch -s -P workloads/workloadf -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=8" > outputRunF.txt
+./bin/ycsb run redisearch -s -P workloads/workloadd -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=8" > outputRunD.txt
+
+redis-cli flushall
+
+./bin/ycsb load redisearch -s -P workloads/workloade -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=8" > outputLoad.txt
+./bin/ycsb run redisearch -s -P workloads/workloade -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=8" > outputRunE.txt
+```
+
+
+## An overall picture, and the RediSearch use-case
+
+### Default workloads
+
+By default, there are 6 default independent workloads, in the core package. Prior to describing the workloads, we will describe the dataset that is similar across all six.
+
+#### RediSearch default workloads dataset representation
+
+All six workloads have a data set that is similar, composed for N distinct records.
+
+Each record is identified by a primary key, which is a string like “user234123”.
+
+
+Within each record, by default, we have 10 fields, named field0, field1 and so on. The values of each field are a random string of ASCII characters of length L.
+By default, we construct 1,000-byte records by using F = 10 fields, each of L = 100 bytes.
+
+Specifically, within Redis, we model each record as a HASH, as showcased below.
+
+Apart from the default fields, within each document we add a numeric `__score__` field, used within the `scan()` workloads for sorting. 
+The value of the `__score__` field is given by computing a hash of the key name.
+
+
+```bash
+127.0.0.1:6379> hgetall user6873002678636213555
+ 1) "field6"
+ 2) "1;x.H{=8`73<+H71+t6W=99\"8(f>Tm*;<4K16?r#?:'<d.!<7\"6!I#'_=(M3!-(-6n>Q99:>8)< P+ 1x2\\%/M\x7f'W%%Sy\"^u%?n+"
+ 3) "field1"
+ 4) ")C3,U!6@-(G!:V5<<d9)j#\\+9&:5S#\":d;&v?>h;<&3)|&\".2< <O{%(:<R90\">4[s-Y'84 '!61%.=(.9R{9Aw*Cc-H=$H'*!,,"
+ 5) "field7"
+ 6) ".(v#Uq'2>=@5%E),*`9]',V->1.9'*&@s6L7:>>,Js:V)17:$Y58^-(Qk?Aq6 r\"Zm Ee&Ag%S=)I%6),)Jy ),=9r5O+%Ug)=x+"
+ 7) "field9"
+ 8) " &f2R).A;43f>Vq;3,<W/9$d#G=,\"4*H%)-(>30 7&4 p;)(=/<<Ny(6~670,(*4N''Ze&&2:P5$Vm728<Ks0 4!C?3;:48>'R}*"
+ 9) "field4"
+10) "4)t&S+08$) f V1)Qm,>,,;6&2`\"!n=Wu#V)4-.=I;5@q+U+$Gq.Ou1H{3Ma<[k.X} .:![\x7f,..8C;\"Ns:Vy<8t6B1<Uq\"E)\" 0$"
+11) "field8"
+12) "8H+ 9d\"^/%968!|;2|+Q-=;f9?`&T%%Sc;>06Bk*]%=U',)8&W5-D+)-*=B)9&p2T}-^'5Kq%(8-K5634 *$)E=1.`+]{?Vi##l+"
+13) "field5"
+14) "\"Sa/W\x7f5&j6C1:5j:R-$8: =(5)&94b(,r6L')+h+G=!8b7T95#>$=:=%t;U?;]+-%(+Yu7P'7#:9<>=Zi?Ok&%<()p&.&-M5<Ow>"
+15) "field3"
+16) "+H9-8t>5|;]}22|&>x$T38,4#\"f3#00\\30R71.*!8n,_i'>:,-f\"Sk:Q9% $?Fa:Q%:E',S;0.h3[);J-$G\x7f-8x\"]'?V!$50>,f6"
+17) "field0"
+18) "23,!Za?Uq?T5-9<=<. B)!2$?$4</h=?$$2`:$x7T%'':<L%+, -]e3^m?\"`16.!I{1.j6R}\"/:<\"4;Dm\"/$>.`6Vs;W7(>l/7z#"
+19) "field2"
+20) "5Dk'Qw==04$*9,b;B+!])$7h44(-8~?H'1!t>D9%?$>5x3Z/%Ek6Kg<H+()6,\".8\"~7W!(F=&7 (Vc4]q#Im7?\"50 ,Qk6Zs4#n:"
+21) "__score__"
+22) "1.770379916E9"
+```
+
+#### Scanning based on RediSearch secondary index…
+
+As you will see below, there is the need to model a scan operation within different records, in which we scan records in order, starting at a randomly chosen record key. 
+The number of records to scan is randomly chosen. 
+
+ To model the scan operation within RedisSearch, we use FT.SEARCH and use computed hash score from the key name as the lower limit
+for the search query, and set +inf as the upper limit of the search result.
+
+ The provided record count is passed via the LIMIT 0 <recordcound> FT.SEARCH argument.
+
+ Together, the above FT.SEARCH command arguments fully comply with a sorted, randomly chosen starting key, with
+ variadic record count replies.
+ 
+Example FT.SEARCH command that a scan operation would generate.
+
+```bash
+127.0.0.1:6379> "FT.SEARCH" "index" "@__score__:[7.39074446E8 inf]" "LIMIT" "0" "13" "RETURN" "10" "field0" "field1" "field2" "field3" "field4" "field5" "field6" "field7" "field8" "field9"
+ 1) (integer) 350
+ 2) "user3232700585171816769"
+ 3)  1) "field0"
+     2) "6;l+P=;R'8F/:Vi77:,S+-5j&8|?,,,0(%,x9_#%?z5+l/4*?1 -'&)@!$8n=^w+Js*)t;S/,<(4J#4=:=8x$[w;X) J#4 r9T90"
+     3) "field1"
+     4) "<4.5]u'Gm/!\"3Bs#%d!U%(Z)1Z-, h3?r'/6 581%x3A55Qs*B34%~ ) )^w-O=0Ok=D=1?4?%v+5(9]+(T=!-b\" x#@o\">6\"$p7"
+     (...)
+     (...)
+    19) "field9"
+    20) "8\"d2Dw7Z)8L?(D75820V?4;h*-*8,4:V+8!8:+>9,(05r3F!=(r2I#)D+)Xm5!*-Xa:O7-987Ti?Ce(8(=]' Mm+Y)*S%5K#7(00"
+ 4) "user1000385178204227360"
+ 5)  1) "field0"
+     2) "'1r;A+(Sc#&:4-x:7|6D-(Z}2<0%66>$ 85v(/84Wo3'\"=3.!0p*+2%#,<-f9+|?7p#Y{/60*5|\"R1/Qk\">z##68F/-*<)*`+Xe*"
+     (...)
+     (...)
+(...)
+(...)
+```
+  
+
+### Workload operation details
+
+#### Workload A: Update heavy workload
+
+- read/scan/update/insert ratio: 50/0/50/0
+- Default data size: 1 KB records (10 fields, 100 bytes each, plus key)
+- Request distribution: Zipfian (some items are more popular than others, according to a Zipfian distribution)
+- Workload: Core ( site.ycsb.workloads.CoreWorkload )
+- Application example: Session store recording recent actions
+
+#### Workload B: Read mostly workload
+
+- read/scan/update/insert ratio: 95/0/5/0
+
+- Default data size: 1 KB records (10 fields, 100 bytes each, plus key)
+
+- Request distribution: Zipfian (some items are more popular than others, according to a Zipfian distribution)
+
+- Workload: Core ( site.ycsb.workloads.CoreWorkload )
+
+- Application example: photo tagging; add a tag is an update, but most operations are to read tags
+
+#### Workload C: Read only
+
+- read/scan/update/insert ratio: 100/0/0/0
+
+- Default data size: 1 KB records (10 fields, 100 bytes each, plus key)
+
+- Request distribution: Zipfian (some items are more popular than others, according to a Zipfian distribution)
+
+- Workload: Core ( site.ycsb.workloads.CoreWorkload )
+
+- Application example: user profile cache, where profiles are constructed elsewhere (e.g., Hadoop)
+
+#### Workload D: Read latest workload
+
+- read/scan/update/insert ratio: 95/0/0/5
+
+- Default data size: 1 KB records (10 fields, 100 bytes each, plus key)
+
+- Request distribution: latest -- new records are inserted, and the most recently inserted records are the most popular.
+
+- Workload: Core ( site.ycsb.workloads.CoreWorkload )
+
+- Application example: user profile cache, where profiles are constructed elsewhere (e.g., Hadoop)
+
+#### Workload E: Short ranges
+
+- read/scan/update/insert ratio: 0/95/0/5
+
+- maxscanlength=100
+
+- scanlengthdistribution=uniform
+
+- This is a 95% read workload, in which short ranges of records are queried, instead of individual records.
+
+- Default data size: 1 KB records (10 fields, 100 bytes each, plus key)
+
+- Request distribution: Zipfian (some items are more popular than others, according to a Zipfian distribution)
+
+- Workload: Core ( site.ycsb.workloads.CoreWorkload )
+
+- Application example: threaded conversations, where each scan is for the posts in a given thread (assumed to be clustered by thread id)
+
+#### Workload F: Read-modify-write workload
+
+- read/scan/update/insert/readmodifywrite ratio: 50/0/0/0/50
+
+- Default data size: 1 KB records (10 fields, 100 bytes each, plus key)
+
+- Request distribution: Zipfian (some items are more popular than others, according to a Zipfian distribution)
+
+- Workload: Core ( site.ycsb.workloads.CoreWorkload )
+
+- Application example: user database, where user records are read and modified by the user or to record user activity.

--- a/redisearch/pom.xml
+++ b/redisearch/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+Copyright (c) 2012 - 2016 YCSB contributors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you
+may not use this file except in compliance with the License. You
+may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License. See accompanying
+LICENSE file.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>11</source>
+          <target>11</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  <parent>
+    <groupId>site.ycsb</groupId>
+    <artifactId>binding-parent</artifactId>
+    <version>0.18.0-SNAPSHOT</version>
+    <relativePath>../binding-parent</relativePath>
+  </parent>
+  
+  <artifactId>redisearch-binding</artifactId>
+  <name>RediSearch DB Binding</name>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>redis.clients</groupId>
+      <artifactId>jedis</artifactId>
+      <version>${redis.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-pool2</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-pool2</artifactId>
+      <version>2.9.0</version>
+    </dependency>
+    <dependency>
+      <groupId>site.ycsb</groupId>
+      <artifactId>core</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>2.0.2</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-to-slf4j</artifactId>
+      <version>2.8.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ignite</groupId>
+      <artifactId>ignite-log4j2</artifactId>
+      <version>2.7.6</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/redisearch/src/main/java/site/ycsb/db/RediSearchClient.java
+++ b/redisearch/src/main/java/site/ycsb/db/RediSearchClient.java
@@ -1,0 +1,327 @@
+/**
+ * Copyright (c) 2021 YCSB contributors. All rights reserved.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ * <p>
+ * RediSearch client binding for YCSB.
+ * <p>
+ * All YCSB records are mapped to a Redis *hash field*.
+ * For scanning we use RediSearch's secondary index capabilities.
+ */
+
+package site.ycsb.db;
+
+import redis.clients.jedis.*;
+import redis.clients.jedis.commands.ProtocolCommand;
+import redis.clients.jedis.util.JedisClusterCRC16;
+import redis.clients.jedis.util.SafeEncoder;
+import site.ycsb.*;
+import site.ycsb.workloads.CoreWorkload;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.*;
+
+/**
+ * YCSB binding for <a href="https://github.com/RediSearch/RediSearch/">RediSearch</a>.
+ * <p>
+ * See {@code redisearch/README.md} for details.
+ */
+public class RediSearchClient extends DB {
+  public static final String HOST_PROPERTY = "redisearch.host";
+  public static final String PORT_PROPERTY = "redisearch.port";
+  public static final String PASSWORD_PROPERTY = "redisearch.password";
+  public static final String CLUSTER_PROPERTY = "redisearch.cluster";
+  public static final String TIMEOUT_PROPERTY = "redisearch.timeout";
+  public static final String INDEX_NAME_PROPERTY = "redisearch.indexname";
+  public static final String INDEX_NAME_PROPERTY_DEFAULT = "index";
+  private JedisCluster jedisCluster;
+  private JedisPool jedisPool;
+  private Boolean clusterEnabled;
+  private int fieldCount;
+  private String fieldPrefix;
+  private String indexName;
+
+  public void init() throws DBException {
+    Properties props = getProperties();
+    int port = Protocol.DEFAULT_PORT;
+    String host = Protocol.DEFAULT_HOST;
+    int timeout = Protocol.DEFAULT_TIMEOUT;
+
+    String redisTimeoutStr = props.getProperty(TIMEOUT_PROPERTY);
+    String password = props.getProperty(PASSWORD_PROPERTY);
+    clusterEnabled = Boolean.parseBoolean(props.getProperty(CLUSTER_PROPERTY));
+    String portString = props.getProperty(PORT_PROPERTY);
+    indexName = props.getProperty(INDEX_NAME_PROPERTY, INDEX_NAME_PROPERTY_DEFAULT);
+    if (portString != null) {
+      port = Integer.parseInt(portString);
+    }
+    if (props.getProperty(HOST_PROPERTY) != null) {
+      host = props.getProperty(HOST_PROPERTY);
+    }
+    if (redisTimeoutStr != null) {
+      timeout = Integer.parseInt(redisTimeoutStr);
+    }
+
+    Jedis setupPoolConn;
+    JedisPoolConfig poolConfig = new JedisPoolConfig();
+    if (clusterEnabled) {
+      Set<HostAndPort> jedisClusterNodes = new HashSet<>();
+      jedisClusterNodes.add(new HostAndPort(host, port));
+      jedisCluster = new JedisCluster(jedisClusterNodes, timeout, timeout, 5, poolConfig);
+      setupPoolConn = jedisCluster.getConnectionFromSlot(1);
+    } else {
+      jedisPool = new JedisPool(poolConfig, host, port, timeout, password);
+      setupPoolConn = jedisPool.getResource();
+    }
+    fieldCount = Integer.parseInt(props.getProperty(
+        CoreWorkload.FIELD_COUNT_PROPERTY, CoreWorkload.FIELD_COUNT_PROPERTY_DEFAULT));
+    fieldPrefix = props.getProperty(
+        CoreWorkload.FIELD_NAME_PREFIX, CoreWorkload.FIELD_NAME_PREFIX_DEFAULT);
+    try {
+      List<String> indexCreateCmdArgs = indexCreateCmdArgs(indexName, fieldCount, fieldPrefix);
+      setupPoolConn.sendCommand(RediSearchCommands.CREATE, indexCreateCmdArgs.toArray(String[]::new));
+    } catch (redis.clients.jedis.exceptions.JedisDataException e) {
+      if (!e.getMessage().contains("Index already exists")) {
+        throw new DBException(e.getMessage());
+      }
+    }
+  }
+
+  /**
+   * Helper method to create the FT.CREATE command arguments, used to add a secondary index definition to Redis.
+   *
+   * @param iName   Index name
+   * @param fCount  fields count
+   * @param fPrefix fields prefix
+   * @return
+   */
+  private List<String> indexCreateCmdArgs(String iName, int fCount, String fPrefix) {
+    List<String> args = new ArrayList<>(Arrays.asList(iName, "ON", "HASH", "SCHEMA",
+        "__score__", "NUMERIC", "SORTABLE"));
+    for (int i = 0; i < fCount; i++) {
+      args.addAll(Arrays.asList(String.format("%s%d", fPrefix, i), "TEXT", "NOINDEX"));
+    }
+    return args;
+  }
+
+
+  public void cleanup() throws DBException {
+    try {
+      if (clusterEnabled) {
+        ((Closeable) jedisCluster).close();
+      } else {
+        ((Closeable) jedisPool).close();
+      }
+    } catch (IOException e) {
+      throw new DBException("Closing connection failed.");
+    }
+  }
+
+  /*
+   * Calculate a hash for a key to store it in an index. The actual return value
+   * of this function is not interesting -- it primarily needs to be fast and
+   * scattered along the whole space of doubles. In a real world scenario one
+   * would probably use the ASCII values of the keys.
+   */
+  private double hash(String key) {
+    return key.hashCode();
+  }
+
+  @Override
+  public Status read(String table, String key, Set<String> fields,
+                     Map<String, ByteIterator> result) {
+    if (fields == null) {
+      Map<String, String> reply;
+      if (clusterEnabled) {
+        reply = jedisCluster.hgetAll(key);
+      } else {
+        try (Jedis jedis = jedisPool.getResource()) {
+          reply = jedis.hgetAll(key);
+        }
+      }
+      extractHGetAllResults(result, reply);
+    } else {
+      List<String> reply;
+      if (clusterEnabled) {
+        reply = jedisCluster.hmget(key, fields.toArray(new String[fields.size()]));
+      } else {
+        try (Jedis jedis = jedisPool.getResource()) {
+          reply = jedis.hmget(key, fields.toArray(new String[fields.size()]));
+        }
+      }
+      extractHmGetResults(fields, result, reply);
+    }
+    return result.isEmpty() ? Status.ERROR : Status.OK;
+  }
+
+  private void extractHGetAllResults(Map<String, ByteIterator> result, Map<String, String> reply) {
+    StringByteIterator.putAllAsByteIterators(result, reply);
+  }
+
+  private void extractHmGetResults(Set<String> fields, Map<String, ByteIterator> result, List<String> values) {
+    Iterator<String> fieldIterator = fields.iterator();
+    Iterator<String> valueIterator = values.iterator();
+
+    while (fieldIterator.hasNext() && valueIterator.hasNext()) {
+      result.put(fieldIterator.next(),
+          new StringByteIterator(valueIterator.next()));
+    }
+  }
+
+  @Override
+  public Status insert(String table, String key,
+                       Map<String, ByteIterator> values) {
+    Jedis j;
+    if (clusterEnabled) {
+      j = jedisCluster.getConnectionFromSlot(JedisClusterCRC16.getCRC16(key));
+    } else {
+      j = jedisPool.getResource();
+    }
+    try {
+      values.put("__score__", new StringByteIterator(String.valueOf(hash(key))));
+      return j.hmset(key, StringByteIterator.getStringMap(values)).equals("OK") ? Status.OK : Status.ERROR;
+    } finally {
+      j.close();
+    }
+  }
+
+  @Override
+  public Status delete(String table, String key) {
+    long res;
+    if (clusterEnabled) {
+      res = jedisCluster.del(key);
+    } else {
+      try (Jedis jedis = jedisPool.getResource()) {
+        res = jedis.del(key);
+      }
+    }
+    return res == 0 ? Status.OK : Status.ERROR;
+  }
+
+  @Override
+  public Status update(String table, String key,
+                       Map<String, ByteIterator> values) {
+    String res;
+    if (clusterEnabled) {
+      res = jedisCluster.hmset(key, StringByteIterator.getStringMap(values));
+    } else {
+      try (Jedis jedis = jedisPool.getResource()) {
+        res = jedis.hmset(key, StringByteIterator.getStringMap(values));
+      }
+    }
+    return res.equals("OK") ? Status.OK : Status.ERROR;
+  }
+
+  /**
+   * As you will see below, there is the need to model a scan operation within different records,
+   * in which we scan records in order, starting at a randomly chosen record key.
+   * The number of records to scan is randomly chosen.
+   * <p>
+   * To model this within RedisSearch, we use FT.SEARCH and use computed hash score from the key name as the lower limit
+   * for the search query, and set +inf as the upper limit of the search result.
+   * The provided record count is passed via the LIMIT 0 <recordcound> FT.SEARCH argument.
+   * Together, the above FT.SEARCH command arguments fully comply with a sorted, randomly choosen starting key, with
+   * variadic record count replies.
+   * <p>
+   * Example FT.SEARCH command that a scan operation would generate.
+   * "FT.SEARCH" "index" "@__score__:[-6.17979116E8 inf]" "LIMIT" "0" "54" "RETURN" "10" "field0" \
+   * "field1" "field2" "field3" "field4" "field5" "field6" "field7" "field8" "field9"
+   *
+   * @param table       The name of the table
+   * @param startkey    The record key of the first record to read.
+   * @param recordcount The number of records to read
+   * @param fields      The list of fields to read, or null for all of them
+   * @param result      A Vector of HashMaps, where each HashMap is a set field/value pairs for one record
+   * @return
+   */
+  @Override
+  public Status scan(String table, String startkey, int recordcount,
+                     Set<String> fields, Vector<HashMap<String, ByteIterator>> result) {
+    Jedis j;
+    Status status = Status.OK;
+    if (clusterEnabled) {
+      j = jedisCluster.getConnectionFromSlot(JedisClusterCRC16.getCRC16(startkey));
+    } else {
+      j = jedisPool.getResource();
+    }
+    try {
+      List<Object> resp = (List<Object>) j.sendCommand(RediSearchCommands.SEARCH,
+          scanCommandArgs(indexName, recordcount, startkey, fields));
+      long totalResult = (long) resp.get(0);
+      for (int i = 1; i < resp.size(); i += 2) {
+        String docname = new String((byte[]) resp.get(i));
+        List<byte[]> docFields = (List<byte[]>) resp.get(i + 1);
+        HashMap<String, ByteIterator> values = new HashMap<String, ByteIterator>();
+        for (int k = 0; k < docFields.size(); k += 2) {
+          values.put(SafeEncoder.encode(docFields.get(k)),
+              new StringByteIterator(SafeEncoder.encode(docFields.get(k + 1))));
+          result.add(values);
+        }
+      }
+    } catch (redis.clients.jedis.exceptions.JedisDataException e) {
+      status = Status.ERROR;
+    } finally {
+      j.close();
+    }
+    return status;
+  }
+
+
+  /**
+   * Helpher method to create the FT.SEARCH args used for the scan() operation.
+   *
+   * @param iName   RediSearch index name
+   * @param rCount  return count
+   * @param sKey    start key
+   * @param rFields fields to retrieve
+   * @return
+   */
+  private String[] scanCommandArgs(String iName, int rCount, String sKey, Set<String> rFields) {
+    int returnFieldsCount = fieldCount;
+    if (rFields != null) {
+      returnFieldsCount = rFields.size();
+    }
+    List<String> scanSearchArgs = new ArrayList<>(Arrays.asList(iName,
+        String.format("@__score__:[%s inf]", hash(sKey)), "LIMIT", "0",
+        String.valueOf(rCount), "RETURN", String.valueOf(returnFieldsCount)));
+
+    if (rFields == null) {
+      for (int i = 0; i < fieldCount; i++) {
+        scanSearchArgs.add(String.format("%s%d", fieldPrefix, i));
+      }
+    } else {
+      for (String field : rFields) {
+        scanSearchArgs.add(field);
+      }
+    }
+    return scanSearchArgs.toArray(String[]::new);
+  }
+
+  /**
+   * RediSearch Protocol commands.
+   */
+  public enum RediSearchCommands implements ProtocolCommand {
+    CREATE,
+    SEARCH;
+    private final byte[] raw = SafeEncoder.encode("FT." + this.name());
+
+    RediSearchCommands() {
+    }
+
+    public byte[] getRaw() {
+      return this.raw;
+    }
+  }
+}

--- a/redisearch/src/main/java/site/ycsb/db/package-info.java
+++ b/redisearch/src/main/java/site/ycsb/db/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2014, Yahoo!, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+/**
+ * The YCSB binding for <a href="http://redis.io/">Redis</a>.
+ */
+package site.ycsb.db;
+


### PR DESCRIPTION


## Description 
This PR enables to run YCSB on Redis with RediSearch[https://github.com/RediSearch/RediSearch] module enabled. 

## Quickstart ( build and run )
Assuming you have RediSearch running and accessible on localhost:6379
Note: check documentation below to understand the order of workloads, what they simulate,etc...
```bash
# build
git clone http://github.com/RediSearch/YCSB.git --branch redisearch2.support
cd YCSB
mvn -pl site.ycsb:redisearch-binding -am clean package

# run 
# load, run A, B, C, F, D, (flushdb), load, E
./bin/ycsb load redisearch -s -P workloads/workloada -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=8" > outputLoad.txt

./bin/ycsb run redisearch -s -P workloads/workloada -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=8" > outputRunA.txt
./bin/ycsb run redisearch -s -P workloads/workloadb -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=8" > outputRunB.txt
./bin/ycsb run redisearch -s -P workloads/workloadc -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=8" > outputRunC.txt
./bin/ycsb run redisearch -s -P workloads/workloadf -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=8" > outputRunF.txt
./bin/ycsb run redisearch -s -P workloads/workloadd -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=8" > outputRunD.txt

redis-cli flushall

./bin/ycsb load redisearch -s -P workloads/workloade -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=8" > outputLoad.txt
./bin/ycsb run redisearch -s -P workloads/workloade -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=8" > outputRunE.txt

```

-----------------------------------------

## Detailed section 
### 1. Start Redis with RediSearch 

```
(...)
```

### 2. Install Java and Maven

### 3. Set Up YCSB

Git clone YCSB and compile:

    git clone http://github.com/RediSearch/YCSB.git --branch redisearch2.support
    cd YCSB
    mvn -pl site.ycsb:redisearch-binding -am clean package

### 4. Provide Redis Connection Parameters
    
Set host, port, password, and cluster mode in the workload you plan to run. 

- `redisearch.host`
- `redisearch.port`
- `redisearch.password`
  * Don't set the password if redis auth is disabled.
- `redisearch.cluster`
  * Set the cluster parameter to `true` if redis cluster mode is enabled.
  * Default is `false`.

Or, you can set configs with the shell command, EG:

    ./bin/ycsb load redisearch -s -P workloads/workloada -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=8" > outputLoad.txt


### 5. Load data and run the tests

All six workloads have a data set that is similar. Workloads D and E insert records during the test run. Thus, to keep the database size consistent, we recommend the following sequence:

Load the database, using workload A’s parameter file (workloads/workloada) and the “-load” switch to the client.

- Run workload A (using workloads/workloada and “-t”) for a variety of throughputs.

- Run workload B (using workloads/workloadb and “-t”) for a variety of throughputs.

- Run workload C (using workloads/workloadc and “-t”) for a variety of throughputs.

- Run workload F (using workloads/workloadf and “-t”) for a variety of throughputs.

- Run workload D (using workloads/workloadd and “-t”) for a variety of throughputs. This workload inserts records, increasing the size of the database.

- Delete the data in the database.

- Reload the database, using workload E’s parameter file (workloads/workloade) and the "-load switch to the client.

- Run workload E (using workloads/workloade and “-t”) for a variety of throughputs. This workload inserts records, increasing the size of the database.


```bash
# load, run A, B, C, F, D, (flushdb), load, E
./bin/ycsb load redisearch -s -P workloads/workloada -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=8" > outputLoad.txt

./bin/ycsb run redisearch -s -P workloads/workloada -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=8" > outputRunA.txt
./bin/ycsb run redisearch -s -P workloads/workloadb -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=8" > outputRunB.txt
./bin/ycsb run redisearch -s -P workloads/workloadc -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=8" > outputRunC.txt
./bin/ycsb run redisearch -s -P workloads/workloadf -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=8" > outputRunF.txt
./bin/ycsb run redisearch -s -P workloads/workloadd -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=8" > outputRunD.txt

redis-cli flushall

./bin/ycsb load redisearch -s -P workloads/workloade -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=8" > outputLoad.txt
./bin/ycsb run redisearch -s -P workloads/workloade -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=8" > outputRunE.txt
```


## An overall picture, and the RediSearch use-case

### Default workloads

By default, there are 6 default independent workloads, in the core package. Prior to describing the workloads, we will describe the dataset that is similar across all six.

#### RediSearch default workloads dataset representation

All six workloads have a data set that is similar, composed for N distinct records.

Each record is identified by a primary key, which is a string like “user234123”.


Within each record, by default, we have 10 fields, named field0, field1 and so on. The values of each field are a random string of ASCII characters of length L.
By default, we construct 1,000-byte records by using F = 10 fields, each of L = 100 bytes.

Specifically, within Redis, we model each record as a HASH, as showcased below.

Apart from the default fields, within each document we add a numeric `__score__` field, used within the `scan()` workloads for sorting. 
The value of the `__score__` field is given by computing a hash of the key name.


```bash
127.0.0.1:6379> hgetall user6873002678636213555
 1) "field6"
 2) "1;x.H{=8`73<+H71+t6W=99\"8(f>Tm*;<4K16?r#?:'<d.!<7\"6!I#'_=(M3!-(-6n>Q99:>8)< P+ 1x2\\%/M\x7f'W%%Sy\"^u%?n+"
 3) "field1"
 4) ")C3,U!6@-(G!:V5<<d9)j#\\+9&:5S#\":d;&v?>h;<&3)|&\".2< <O{%(:<R90\">4[s-Y'84 '!61%.=(.9R{9Aw*Cc-H=$H'*!,,"
 5) "field7"
 6) ".(v#Uq'2>=@5%E),*`9]',V->1.9'*&@s6L7:>>,Js:V)17:$Y58^-(Qk?Aq6 r\"Zm Ee&Ag%S=)I%6),)Jy ),=9r5O+%Ug)=x+"
 7) "field9"
 8) " &f2R).A;43f>Vq;3,<W/9$d#G=,\"4*H%)-(>30 7&4 p;)(=/<<Ny(6~670,(*4N''Ze&&2:P5$Vm728<Ks0 4!C?3;:48>'R}*"
 9) "field4"
10) "4)t&S+08$) f V1)Qm,>,,;6&2`\"!n=Wu#V)4-.=I;5@q+U+$Gq.Ou1H{3Ma<[k.X} .:![\x7f,..8C;\"Ns:Vy<8t6B1<Uq\"E)\" 0$"
11) "field8"
12) "8H+ 9d\"^/%968!|;2|+Q-=;f9?`&T%%Sc;>06Bk*]%=U',)8&W5-D+)-*=B)9&p2T}-^'5Kq%(8-K5634 *$)E=1.`+]{?Vi##l+"
13) "field5"
14) "\"Sa/W\x7f5&j6C1:5j:R-$8: =(5)&94b(,r6L')+h+G=!8b7T95#>$=:=%t;U?;]+-%(+Yu7P'7#:9<>=Zi?Ok&%<()p&.&-M5<Ow>"
15) "field3"
16) "+H9-8t>5|;]}22|&>x$T38,4#\"f3#00\\30R71.*!8n,_i'>:,-f\"Sk:Q9% $?Fa:Q%:E',S;0.h3[);J-$G\x7f-8x\"]'?V!$50>,f6"
17) "field0"
18) "23,!Za?Uq?T5-9<=<. B)!2$?$4</h=?$$2`:$x7T%'':<L%+, -]e3^m?\"`16.!I{1.j6R}\"/:<\"4;Dm\"/$>.`6Vs;W7(>l/7z#"
19) "field2"
20) "5Dk'Qw==04$*9,b;B+!])$7h44(-8~?H'1!t>D9%?$>5x3Z/%Ek6Kg<H+()6,\".8\"~7W!(F=&7 (Vc4]q#Im7?\"50 ,Qk6Zs4#n:"
21) "__score__"
22) "1.770379916E9"
```

#### Scanning based on RediSearch secondary index…

As you will see below, there is the need to model a scan operation within different records, in which we scan records in order, starting at a randomly chosen record key. 
The number of records to scan is randomly chosen. 

 To model the scan operation within RedisSearch, we use FT.SEARCH and use computed hash score from the key name as the lower limit
for the search query, and set +inf as the upper limit of the search result.

 The provided record count is passed via the LIMIT 0 <recordcound> FT.SEARCH argument.

 Together, the above FT.SEARCH command arguments fully comply with a sorted, randomly chosen starting key, with
 variadic record count replies.
 
Example FT.SEARCH command that a scan operation would generate.

```bash
127.0.0.1:6379> "FT.SEARCH" "index" "@__score__:[7.39074446E8 inf]" "LIMIT" "0" "13" "RETURN" "10" "field0" "field1" "field2" "field3" "field4" "field5" "field6" "field7" "field8" "field9"
 1) (integer) 350
 2) "user3232700585171816769"
 3)  1) "field0"
     2) "6;l+P=;R'8F/:Vi77:,S+-5j&8|?,,,0(%,x9_#%?z5+l/4*?1 -'&)@!$8n=^w+Js*)t;S/,<(4J#4=:=8x$[w;X) J#4 r9T90"
     3) "field1"
     4) "<4.5]u'Gm/!\"3Bs#%d!U%(Z)1Z-, h3?r'/6 581%x3A55Qs*B34%~ ) )^w-O=0Ok=D=1?4?%v+5(9]+(T=!-b\" x#@o\">6\"$p7"
     (...)
     (...)
    19) "field9"
    20) "8\"d2Dw7Z)8L?(D75820V?4;h*-*8,4:V+8!8:+>9,(05r3F!=(r2I#)D+)Xm5!*-Xa:O7-987Ti?Ce(8(=]' Mm+Y)*S%5K#7(00"
 4) "user1000385178204227360"
 5)  1) "field0"
     2) "'1r;A+(Sc#&:4-x:7|6D-(Z}2<0%66>$ 85v(/84Wo3'\"=3.!0p*+2%#,<-f9+|?7p#Y{/60*5|\"R1/Qk\">z##68F/-*<)*`+Xe*"
     (...)
     (...)
(...)
(...)
```
  

### Workload operation details

#### Workload A: Update heavy workload

- read/scan/update/insert ratio: 50/0/50/0
- Default data size: 1 KB records (10 fields, 100 bytes each, plus key)
- Request distribution: Zipfian (some items are more popular than others, according to a Zipfian distribution)
- Workload: Core ( site.ycsb.workloads.CoreWorkload )
- Application example: Session store recording recent actions

#### Workload B: Read mostly workload

- read/scan/update/insert ratio: 95/0/5/0

- Default data size: 1 KB records (10 fields, 100 bytes each, plus key)

- Request distribution: Zipfian (some items are more popular than others, according to a Zipfian distribution)

- Workload: Core ( site.ycsb.workloads.CoreWorkload )

- Application example: photo tagging; add a tag is an update, but most operations are to read tags

#### Workload C: Read only

- read/scan/update/insert ratio: 100/0/0/0

- Default data size: 1 KB records (10 fields, 100 bytes each, plus key)

- Request distribution: Zipfian (some items are more popular than others, according to a Zipfian distribution)

- Workload: Core ( site.ycsb.workloads.CoreWorkload )

- Application example: user profile cache, where profiles are constructed elsewhere (e.g., Hadoop)

#### Workload D: Read latest workload

- read/scan/update/insert ratio: 95/0/0/5

- Default data size: 1 KB records (10 fields, 100 bytes each, plus key)

- Request distribution: latest -- new records are inserted, and the most recently inserted records are the most popular.

- Workload: Core ( site.ycsb.workloads.CoreWorkload )

- Application example: user profile cache, where profiles are constructed elsewhere (e.g., Hadoop)

#### Workload E: Short ranges

- read/scan/update/insert ratio: 0/95/0/5

- maxscanlength=100

- scanlengthdistribution=uniform

- This is a 95% read workload, in which short ranges of records are queried, instead of individual records.

- Default data size: 1 KB records (10 fields, 100 bytes each, plus key)

- Request distribution: Zipfian (some items are more popular than others, according to a Zipfian distribution)

- Workload: Core ( site.ycsb.workloads.CoreWorkload )

- Application example: threaded conversations, where each scan is for the posts in a given thread (assumed to be clustered by thread id)

#### Workload F: Read-modify-write workload

- read/scan/update/insert/readmodifywrite ratio: 50/0/0/0/50

- Default data size: 1 KB records (10 fields, 100 bytes each, plus key)

- Request distribution: Zipfian (some items are more popular than others, according to a Zipfian distribution)

- Workload: Core ( site.ycsb.workloads.CoreWorkload )

- Application example: user database, where user records are read and modified by the user or to record user activity.
